### PR TITLE
fix error when dictionary search threshold is larger than keyword

### DIFF
--- a/lua/blink-cmp-words/source.lua
+++ b/lua/blink-cmp-words/source.lua
@@ -121,7 +121,9 @@ local function create_source(source_type)
 				success, matches, error =
 					pcall(wordnet.get_word_matches, keyword, self.opts.dictionary_search_threshold)
 			else
+				success = true
 				matches = {}
+				error = nil
 			end
 		else -- thesaurus
 			success, matches, error =


### PR DESCRIPTION
When the dictionary source is enabled and I start typing I get the following error:

```
failed to get completions with error: ...nvim/lazy/blink-cmp-words/lua/blink-cmp-words/source.lua:132: attempt to concatenate local 'error' (a nil value)
```

The problem is that when the keyword is smaller than the threshold, the success variable is not set to anything.